### PR TITLE
Fix : popup requête WinIBW translucide

### DIFF
--- a/src/components/resultats/PopupRequestWinibw.vue
+++ b/src/components/resultats/PopupRequestWinibw.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="props.dialog">
     <template v-slot:default="dialog">
-      <v-card>
+      <v-card color="white">
         <v-toolbar
             color="#252C61"
             dark


### PR DESCRIPTION
   - correction du bug d'affichage de la popup "générer la requête pour WinIBW"