### PR TITLE
Consomme le resultat asynchrone dans le front

### DIFF
--- a/src/components/BoutonLancement.vue
+++ b/src/components/BoutonLancement.vue
@@ -16,19 +16,15 @@
 
 <script setup>
 import { useAnalyseStore } from "@/stores/analyse";
-import { useResultatStore } from "@/stores/resultat";
-import { useHistoriqueStore } from "@/stores/historique";
 import QualimarcService from "@/service/QualimarcService";
 import {ref} from "vue";
 
 // Store
 const analyseStore = useAnalyseStore();
-const resultatStore = useResultatStore();
-const historiqueStore = useHistoriqueStore();
 
 // Props & Emit
 const props = defineProps({isDisabled: Boolean, isReplay: Boolean});
-const emit = defineEmits(['backendError', 'finished', 'started']);
+const emit = defineEmits(['backendError', 'started']);
 
 // Service
 const serviceApi = QualimarcService;
@@ -37,69 +33,28 @@ const serviceApi = QualimarcService;
 const spinnerActive = ref(false);
 
 function checkPpnWithTypeAnalyse() {
-  const startedAt = performance.now();
   const ppnCount = analyseStore.getPpnValidsList.length;
   const analysisType = analyseStore.getAnalyseSelected.id;
 
   spinnerActive.value = true;
-  emit('started');
+  serviceApi.startAnalysisTracking(ppnCount, analysisType, props.isReplay);
   serviceApi.checkPpnWithTypeAnalyse(analyseStore.getPpnValidsList, analyseStore.getAnalyseSelected.id, analyseStore.getFamilleDocumentSet, analyseStore.getRuleSet, props.isReplay)
-    .then((response) => {
-      logAnalysisDuration('terminee', startedAt, ppnCount, analysisType);
-      resultatStore.setResultsListArray(response.data.resultRules);
-      resultatStore.pushRecapitulatif(
-        response.data.ppnAnalyses,
-        response.data.ppnInconnus,
-        response.data.ppnErrones,
-        response.data.ppnOk
-      );
-      if(props.isReplay) {
-        historiqueStore.pushReplayedResultatToLastHistorique(
-          resultatStore.getLastRecapitulatif
-        );
-      } else {
-        historiqueStore.createNewHistorique(
-            {
-              ppnValidsList: analyseStore.getPpnValidsList,
-              ppnInvalidsList: analyseStore.getPpnInvalidsList,
-              analyseSelected : analyseStore.getAnalyseSelected,
-              familleDocumentSet : analyseStore.getFamilleDocumentSet,
-              ruleSet : analyseStore.getRuleSet,
-            },
-            resultatStore.getLastRecapitulatif
-        );
-      }
-      emitOnFinished();
+    .then(() => {
+      emit('started');
     })
     .catch((error) => {
-      if(error.message === 'canceled') {
-        logAnalysisDuration('annulee', startedAt, ppnCount, analysisType);
+      if(error.message === 'canceled' || error.code === 'ERR_CANCELED') {
+        serviceApi.logAnalysisDuration('annulee');
       }else {
-        logAnalysisDuration('en erreur', startedAt, ppnCount, analysisType);
+        serviceApi.logAnalysisDuration('en erreur');
         emitOnError(error);
       }
     })
     .finally(() => spinnerActive.value = false);
 }
 
-function logAnalysisDuration(status, startedAt, ppnCount, analysisType) {
-  const durationMs = Math.round(performance.now() - startedAt);
-
-  console.info('[Qualimarc] Analyse ' + status, {
-    dureeMs: durationMs,
-    dureeSecondes: Number((durationMs / 1000).toFixed(3)),
-    nbPpn: ppnCount,
-    typeAnalyse: analysisType,
-    replay: props.isReplay,
-  });
-}
-
 function emitOnError(error){
   emit('backendError', error);
-}
-
-function emitOnFinished(){
-  emit('finished');
 }
 
 </script>

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -51,6 +51,7 @@ const count = ref('0%');
 const isCanceled = ref(false);
 const pollingIntervalId = ref(null);
 const isStatusRequestPending = ref(false);
+const isResultRequestPending = ref(false);
 
 watch(isLoading, (loading) => {
     if (loading) {
@@ -68,23 +69,35 @@ onBeforeUnmount(() => {
 function startPolling() {
     count.value = '0%';
     isCanceled.value = false;
+    isStatusRequestPending.value = false;
+    isResultRequestPending.value = false;
     stopPolling();
 
     pollingIntervalId.value = window.setInterval(async () => {
-        if ((count.value === '100%') && !isLoading.value) {
-            stopPolling();
-            finish();
-            return;
-        }
-
         if (isCanceled.value) {
             stopPolling();
             return;
         }
 
         if (count.value.replace('%', '') > 100) {
-            emit('error', 'Une erreur inattendue est survenue sur le serveur. Merci de relancer votre analyse.');
-            cancel();
+            handleUnexpectedError();
+            return;
+        }
+
+        if ((count.value === '100%') && !isResultRequestPending.value) {
+            isResultRequestPending.value = true;
+            try {
+                const response = await serviceApi.getResult();
+                if (response?.status === 200) {
+                    serviceApi.logAnalysisDuration('terminee');
+                    isLoading.value = false;
+                    finish(response.data);
+                }
+            } catch (error) {
+                handleUnexpectedError(error);
+            } finally {
+                isResultRequestPending.value = false;
+            }
             return;
         }
 
@@ -95,6 +108,8 @@ function startPolling() {
                 if (response?.data) {
                     count.value = response.data;
                 }
+            } catch (error) {
+                handleUnexpectedError(error);
             } finally {
                 isStatusRequestPending.value = false;
             }
@@ -112,13 +127,21 @@ function stopPolling() {
 function cancel() {
     isCanceled.value = true;
     stopPolling();
+    serviceApi.logAnalysisDuration('annulee');
     serviceApi.cancel();
     emit('cancel', true);
 }
 
-function finish() {
+function finish(result) {
     stopPolling();
-    emit('finished');
+    emit('finished', result);
+}
+
+function handleUnexpectedError() {
+    stopPolling();
+    isLoading.value = false;
+    serviceApi.logAnalysisDuration('en erreur');
+    emit('error', 'Une erreur inattendue est survenue sur le serveur. Merci de relancer votre analyse.');
 }
 </script>
 

--- a/src/service/QualimarcService.js
+++ b/src/service/QualimarcService.js
@@ -10,6 +10,7 @@ export class QualimarcService {
 
     controller = new AbortController();
     randomId = null;
+    currentAnalysis = null;
 
     async ensureRandomId() {
         if (!this.randomId) {
@@ -17,10 +18,40 @@ export class QualimarcService {
             this.randomId = response.data;
         }
     }
+
+    startAnalysisTracking(ppnCount, analysisType, isReplay) {
+        this.currentAnalysis = {
+            startedAt: performance.now(),
+            ppnCount: ppnCount,
+            analysisType: analysisType,
+            isReplay: isReplay,
+        };
+    }
+
+    logAnalysisDuration(status) {
+        if (!this.currentAnalysis) {
+            this.randomId = null;
+            return;
+        }
+
+        const durationMs = Math.round(performance.now() - this.currentAnalysis.startedAt);
+
+        console.info('[Qualimarc] Analyse ' + status, {
+            dureeMs: durationMs,
+            dureeSecondes: Number((durationMs / 1000).toFixed(3)),
+            nbPpn: this.currentAnalysis.ppnCount,
+            typeAnalyse: this.currentAnalysis.analysisType,
+            replay: this.currentAnalysis.isReplay,
+        });
+
+        this.currentAnalysis = null;
+        this.randomId = null;
+    }
+
     cancel() {
-        // Cancel the request
         this.controller.abort();
         this.controller = new AbortController();
+        this.randomId = null;
     }
 
         /**
@@ -33,6 +64,7 @@ export class QualimarcService {
          * @returns {Promise<AxiosResponse<any>>}
          */
     async checkPpnWithTypeAnalyse(ppnList, typeAnalyse, famillesDocuments, ruleSet, isReplay) {
+        this.randomId = null;
         await this.ensureRandomId();
         let data = {
             id: this.randomId,
@@ -128,6 +160,18 @@ export class QualimarcService {
         await this.ensureRandomId();
         try {
             return await this.client.get("getStatus/" + this.randomId, {signal: this.controller.signal})
+        } catch (error) {
+            if (error.message === 'canceled' || error.code === 'ERR_CANCELED') {
+                return null;
+            }
+            throw error;
+        }
+    }
+
+    async getResult() {
+        await this.ensureRandomId();
+        try {
+            return await this.client.get("result/" + this.randomId, {signal: this.controller.signal})
         } catch (error) {
             if (error.message === 'canceled' || error.code === 'ERR_CANCELED') {
                 return null;

--- a/src/views/Accueil.vue
+++ b/src/views/Accueil.vue
@@ -3,7 +3,7 @@
     <h1 class="ml-1 mb-2 fontPrimaryColor" style="font-size: 1em; font-weight: 400">Outil d'analyse des notices
       bibliographiques du Sudoc</h1>
     <progress-bar v-model:isLoading="isProgressLoading" @cancel="stopAnalyse" @error="setMessageErreur"
-                  @finished="redirect"></progress-bar>
+                  @finished="handleAnalysisFinished"></progress-bar>
     <v-row class="mb-2 pa-2" justify="space-between">
       <v-col class="ma-2 pa-2" style="min-height: 34em;">
         <h2 style="font-size: 1.26em; color : #252C61; font-weight: bold">
@@ -26,7 +26,6 @@
             :isDisabled="(isPpnListIsEmpty || !isAnalyseSelected)"
             class="mb-2 pa-0"
             @backendError="setBackendError"
-            @finished="maskAndStopProgress"
             @started="displayAndStartProgress"
         >
           Lancer l'analyse
@@ -44,6 +43,7 @@ import {onMounted, ref} from 'vue';
 import router from "@/router";
 import {useResultatStore} from "@/stores/resultat";
 import {useAnalyseStore} from "@/stores/analyse";
+import {useHistoriqueStore} from "@/stores/historique";
 import ProgressBar from "@/components/ProgressBar.vue";
 
 const isAnalyseSelected = ref(false);
@@ -54,6 +54,7 @@ const messageErreur = ref(null);
 //Store
 const resultatStore = useResultatStore();
 const analyseStore = useAnalyseStore();
+const historiqueStore = useHistoriqueStore();
 
 onMounted(() => {
   resultatStore.$reset();
@@ -90,19 +91,33 @@ function displayAndStartProgress() {
   resetErrorMessage();
 }
 
-function maskAndStopProgress() {
+function handleAnalysisFinished(responseData) {
+  resultatStore.setResultsListArray(responseData.resultRules);
+  resultatStore.pushRecapitulatif(
+    responseData.ppnAnalyses,
+    responseData.ppnInconnus,
+    responseData.ppnErrones,
+    responseData.ppnOk
+  );
+  historiqueStore.createNewHistorique(
+      {
+        ppnValidsList: analyseStore.getPpnValidsList,
+        ppnInvalidsList: analyseStore.getPpnInvalidsList,
+        analyseSelected : analyseStore.getAnalyseSelected,
+        familleDocumentSet : analyseStore.getFamilleDocumentSet,
+        ruleSet : analyseStore.getRuleSet,
+      },
+      resultatStore.getLastRecapitulatif
+  );
   isProgressLoading.value = false;
   backendErrorMessage.value = null;
+  setTimeout(() => {
+    router.push('/resultats');
+  }, 0);
 }
 
 function stopAnalyse() {
   isProgressLoading.value = false;
-}
-
-function redirect() {
-  setTimeout(() => {
-    router.push('/resultats');
-  }, 0);
 }
 
 function resetErrorMessage() {

--- a/src/views/Resultat.vue
+++ b/src/views/Resultat.vue
@@ -5,7 +5,7 @@
         :items-sorted-and-filtered="itemsSortedAndFiltered"
     />
     <ProgressBar v-model:isLoading="isProgressLoading" @cancel="stopAnalyse"
-                 @finished="updateNbLancement"></ProgressBar>
+                 @error="stopAnalyse" @finished="handleReplayFinished"></ProgressBar>
     <div class="ma-0 pa-0 mb-2" style="color: #595959; font-size: 0.9em">
       <nav aria-label="fil d'Ariane" class="filAriane">
         <ul>
@@ -94,7 +94,6 @@
           <BoutonLancement
               class="ma-0 pa-0"
               is-replay
-              @finished="maskAndStopProgress"
               @started="displayAndStartProgress"
           >
             Relancer l'analyse
@@ -115,11 +114,13 @@ import DownloadCsv from "@/components/DownloadCsv.vue";
 
 import {onBeforeMount, ref} from "vue";
 import {useResultatStore} from "@/stores/resultat";
+import {useHistoriqueStore} from "@/stores/historique";
 import KeyboardNavigation from "@/components/resultats/KeyboardNavigation.vue";
 import {useRouter} from 'vue-router'
 
 const router = useRouter()
 const resultatStore = useResultatStore();
+const historiqueStore = useHistoriqueStore();
 
 const currentPpn = ref('');
 const itemsSortedAndFiltered = ref([]);
@@ -178,12 +179,23 @@ function updateNbLancement() {
   nbLancement.value = resultatStore.getRecapitulatif.length;
 }
 
-function displayAndStartProgress() {
-  isProgressLoading.value = true;
+function handleReplayFinished(responseData) {
+  resultatStore.setResultsListArray(responseData.resultRules);
+  resultatStore.pushRecapitulatif(
+      responseData.ppnAnalyses,
+      responseData.ppnInconnus,
+      responseData.ppnErrones,
+      responseData.ppnOk
+  );
+  historiqueStore.pushReplayedResultatToLastHistorique(
+      resultatStore.getLastRecapitulatif
+  );
+  isProgressLoading.value = false;
+  updateNbLancement();
 }
 
-function maskAndStopProgress() {
-  isProgressLoading.value = false;
+function displayAndStartProgress() {
+  isProgressLoading.value = true;
 }
 
 function stopAnalyse() {


### PR DESCRIPTION
## Objectif
- adapter l'interface au nouveau lancement asynchrone des analyses pour ne plus attendre la reponse finale sur `POST /check`

## Modifications
- fait lancer l'analyse par le bouton sans attendre les resultats metier
- fait recuperer le resultat final par la barre de progression quand le backend annonce `100%`
- deplace l'alimentation des stores de resultats et d'historique a la fin effective de l'analyse
- conserve la journalisation de la duree totale d'analyse dans la console du navigateur
- reinitialise l'identifiant client entre deux analyses pour repartir d'une session propre

## Verification
- `npm run build`
